### PR TITLE
setup.py did not work since BasicUsageEnvironment was missing at library_dirs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,24 @@
 from distutils.core import setup, Extension
 
-INSTALL_DIR = './live'
-module = Extension('live555',
-                   include_dirs=['%s/%s/include' % (INSTALL_DIR, x) for x in ['liveMedia', 'BasicUsageEnvironment', 'UsageEnvironment', 'groupsock']],
-                   libraries=['liveMedia', 'groupsock', 'BasicUsageEnvironment', 'UsageEnvironment'],
-                   #extra_compile_args = ['-fPIC'],
-                   library_dirs=['%s/%s' % (INSTALL_DIR, x) for x in ['liveMedia', 'UsageEnvironment', 'groupsock']],
-                   sources = ['module.cpp'])
-  
-setup(name = 'live555',
-      version = '1.0',
-      description = 'Basic wrapper around live555 to load RTSP video streams',
-      ext_modules = [module])
+INSTALL_DIR = "./live"
+module = Extension(
+    "live555",
+    include_dirs=[
+        "%s/%s/include" % (INSTALL_DIR, x)
+        for x in ["liveMedia", "BasicUsageEnvironment", "UsageEnvironment", "groupsock"]
+    ],
+    libraries=["liveMedia", "groupsock", "BasicUsageEnvironment", "UsageEnvironment"],
+    # extra_compile_args = ['-fPIC'],
+    library_dirs=[
+        "%s/%s" % (INSTALL_DIR, x)
+        for x in ["liveMedia", "BasicUsageEnvironment", "UsageEnvironment", "groupsock"]
+    ],
+    sources=["module.cpp"],
+)
+
+setup(
+    name="live555",
+    version="1.0",
+    description="Basic wrapper around live555 to load RTSP video streams",
+    ext_modules=[module],
+)


### PR DESCRIPTION
The directory BasicUsageEnvironment was missing at library_dirs and the command python3 setup.py build complained with:

`/usr/bin/ld: cannot find -lBasicUsageEnvironment
collect2: error: ld returned 1 exit status
error: command 'x86_64-linux-gnu-g++' failed with exit status 1
`

Adding BasicUsageEnvironment to library_dirs fixes the issue.